### PR TITLE
Add homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "keywords": [],
   "author": "Brent Jackson",
   "license": "MIT",
+  "homepage": "https://github.com/c8r/initit",
   "dependencies": {
     "arg": "^2.0.0",
     "cross-spawn": "^6.0.5",


### PR DESCRIPTION
I saw the `initit` package in the source for mdx-deck and was curious about it. The npm page doesn't show a link to a GitHub repo, so adding the `homepage` key to point here could help direct people to the source to contribute or view the source online.

![image](https://user-images.githubusercontent.com/2344137/44681251-fad24a00-a9f4-11e8-9ebb-cb2c185e7733.png)
