### PR TITLE
makes tar extraction depth configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,10 +30,11 @@ const getTar = ({
   user,
   repo,
   path = '',
-  name
+  name,
+  depth = 3
 }) => {
   const url = `https://codeload.github.com/${user}/${repo}/tar.gz/master`
-  const cmd = `curl ${url} | tar -xz -C ${name} --strip=3 ${repo}-master/${path}`
+  const cmd = `curl ${url} | tar -xz -C ${name} --strip=${depth} ${repo}-master/${path}`
   exec(cmd, { stdio: 'inherit' })
 }
 
@@ -51,6 +52,7 @@ const create = async (opts = {}) => {
   const dirname = path.resolve(opts.name)
   const name = path.basename(dirname)
   const [ user, repo, ...paths ] = opts.template.split('/')
+  const depth = opts.templateDepth
 
   fs.ensureDirSync(name)
 
@@ -58,7 +60,8 @@ const create = async (opts = {}) => {
     name,
     user,
     repo,
-    path: paths.join('/')
+    path: paths.join('/'),
+    depth
   }))
 
   const templatePkg = require(

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const getTar = ({
   repo,
   path = '',
   name,
-  depth = 3
+  depth
 }) => {
   const url = `https://codeload.github.com/${user}/${repo}/tar.gz/master`
   const cmd = `curl ${url} | tar -xz -C ${name} --strip=${depth} ${repo}-master/${path}`
@@ -52,7 +52,7 @@ const create = async (opts = {}) => {
   const dirname = path.resolve(opts.name)
   const name = path.basename(dirname)
   const [ user, repo, ...paths ] = opts.template.split('/')
-  const depth = opts.templateDepth
+  const depth = paths.length+1
 
   fs.ensureDirSync(name)
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const getTar = ({
   repo,
   path = '',
   name,
-  depth
+  depth = 3
 }) => {
   const url = `https://codeload.github.com/${user}/${repo}/tar.gz/master`
   const cmd = `curl ${url} | tar -xz -C ${name} --strip=${depth} ${repo}-master/${path}`


### PR DESCRIPTION
This defaults to 3 for consistency, but makes template depth (in repo) configurable. If someone wanted a template from the root of a project, they would pass `1` in as the `templateDepth`.

This addresses #3.